### PR TITLE
Add Docker-based dev environment

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,14 @@
+# [Choice] Node.js version (use -bullseye variants on local arm64/Apple Silicon): 16, 14, 12, 16-bullseye, 14-bullseye, 12-bullseye, 16-buster, 14-buster, 12-buster
+ARG VARIANT=16-bullseye
+FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:0-${VARIANT}
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+
+# [Optional] Uncomment if you want to install an additional version of node using nvm
+# ARG EXTRA_NODE_VERSION=10
+# RUN su node -c "source /usr/local/share/nvm/nvm.sh && nvm install ${EXTRA_NODE_VERSION}"
+
+# [Optional] Uncomment if you want to install more global node modules
+# RUN su node -c "npm install -g <your-package-list-here>"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,46 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.205.2/containers/javascript-node-postgres
+// Update the VARIANT arg in docker-compose.yml to pick a Node.js version
+{
+  "name": "Apollo",
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "app",
+  "workspaceFolder": "/workspace",
+
+  // Set *default* container specific settings.json values on container create.
+  "settings": {
+    "sqltools.connections": [
+      {
+        "name": "Container database",
+        "driver": "MySQL",
+        "previewLimit": 50,
+        "server": "localhost",
+        "port": 33060,
+        "database": "apollo",
+        "username": "apollo",
+        "password": "apollo123",
+        "connectionTimeout": 15,
+        "mysqlOptions": {
+          "authProtocol": "xprotocol"
+        }
+      }
+    ]
+  },
+
+  // Add the IDs of extensions you want installed when the container is created.
+  "extensions": [
+    "dbaeumer.vscode-eslint",
+    "mtxr.sqltools",
+    "mtxr.sqltools-driver-mysql",
+    "arcanis.vscode-zipfs"
+  ],
+
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  "forwardPorts": [3999, 3306],
+
+  // Use 'postCreateCommand' to run commands after the container is created.
+  "postCreateCommand": "yarn install",
+
+  // Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+  "remoteUser": "node"
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,45 @@
+version: '3.8'
+
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        # Update 'VARIANT' to pick an LTS version of Node.js: 16, 14, 12.
+        # Append -bullseye or -buster to pin to an OS version.
+        # Use -bullseye variants on local arm64/Apple Silicon.
+        VARIANT: 16-bullseye
+
+    volumes:
+      - ..:/workspace:cached
+
+    # Overrides default command so things don't shut down after the process ends.
+    command: sleep infinity
+
+    # Runs app on the same network as the database container, allows "forwardPorts" in devcontainer.json function.
+    network_mode: service:db
+
+    # Uncomment the next line to use a non-root user for all processes.
+    # user: node
+
+    # Use "forwardPorts" in **devcontainer.json** to forward an app port locally.
+    # (Adding the "ports" property to this file will not forward from a Codespace.)
+
+  db:
+    image: mysql:8
+    restart: unless-stopped
+    volumes:
+      - mysql-data:/var/lib/mysql
+      - ./mysql/init.sql:/docker-entrypoint-initdb.d/init.sql
+    environment:
+      MYSQL_ROOT_PASSWORD: demo
+      MYSQL_USER: apollo@localhost
+      MYSQL_PASSWORD: apollo123
+      MYSQL_DATABASE: apollo
+
+    # Add "forwardPorts": ["3306"] to **devcontainer.json** to forward MySQL locally.
+    # (Adding the "ports" property to this file will not forward from a Codespace.)
+
+volumes:
+  mysql-data:

--- a/.devcontainer/mysql/init.sql
+++ b/.devcontainer/mysql/init.sql
@@ -1,0 +1,36 @@
+CREATE TABLE `grails_user` (
+  `id` bigint(20) NOT NULL AUTO_INCREMENT,
+  `version` bigint(20) NOT NULL,
+  `first_name` varchar(255) NOT NULL,
+  `inactive` bit(1) NOT NULL,
+  `last_name` varchar(255) NOT NULL,
+  `metadata` varchar(255) DEFAULT NULL,
+  `password_hash` varchar(255) NOT NULL,
+  `username` varchar(255) NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `UK_rdmcxcj6i53kfjmb9j811ta1m` (`username`)
+) ENGINE = InnoDB AUTO_INCREMENT = 1 DEFAULT CHARSET = utf8mb4;
+CREATE TABLE `role` (
+  `id` bigint(20) NOT NULL AUTO_INCREMENT,
+  `version` bigint(20) NOT NULL,
+  `name` varchar(255) NOT NULL,
+  `rank` int(11) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `UK_8sewwnpamngi6b1dwaa88askk` (`name`),
+  UNIQUE KEY `UK_1uxpq87pyp6d4vp86es3ew5lf` (`rank`)
+) ENGINE = InnoDB AUTO_INCREMENT = 1 DEFAULT CHARSET = utf8mb4;
+CREATE TABLE `grails_user_roles` (
+  `role_id` bigint(20) NOT NULL,
+  `user_id` bigint(20) NOT NULL,
+  PRIMARY KEY (`user_id`, `role_id`),
+  KEY `FK_4mxkyj2itw9wyvcn6d8d4mta2` (`role_id`),
+  CONSTRAINT `FK_4mxkyj2itw9wyvcn6d8d4mta2` FOREIGN KEY (`role_id`) REFERENCES `role` (`id`),
+  CONSTRAINT `FK_jsuq1rc9mb07tg4kubnqn8yw6` FOREIGN KEY (`user_id`) REFERENCES `grails_user` (`id`)
+) ENGINE = InnoDB AUTO_INCREMENT = 1 DEFAULT CHARSET = utf8mb4;
+INSERT INTO role (`version`, `name`, `rank`)
+VALUES(1, 'USER', 10);
+INSERT INTO role (`version`, `name`, `rank`)
+VALUES(1, 'INSTRUCTOR', 50);
+INSERT INTO role (`version`, `name`, `rank`)
+VALUES(1, 'ADMIN', 100);
+COMMIT;

--- a/packages/apollo-collaboration-server/src/main.ts
+++ b/packages/apollo-collaboration-server/src/main.ts
@@ -10,7 +10,7 @@ async function bootstrap() {
     //logger: ['error', 'warn'],
   })
   //const app = await NestFactory.create(AppModule);
-  await app.listen(3000)
+  await app.listen(3999)
   console.log(`Application is running on: ${await app.getUrl()}`)
 }
 bootstrap()


### PR DESCRIPTION
This adds a Docker-based development environment that can easily be integrated with Visual Studio Code. More information about developing in a container can be found [here](https://code.visualstudio.com/docs/remote/containers), but the basic steps are to install Docker on your computer and the [Remote - Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension in vscode and then run the command "Reopen in Container" in vscode. (If on Linux, you'll have to install `docker-compose` separately, but on Windows and Mac it comes packaged with Docker Desktop).

It actually uses two Docker containers together with `docker-compose`, a Node.js container with `npm`, `yarn`, etc. installed, and a MySQL container for the database. This helps keeps concerns separated and helps rebuild time be fast since it's using pre-built containers.

To use the docker env without opening in vscode, you can do:

```sh
cd .devcontainer/
docker-compose up
# Once it's up, list the running containers with
docker ps
# Get the ID of the Node.js container from `docker ps` and attach to it using
docker exec -it <ID> bash
```

The first time the container is created, it's initialized with the `mysql/init.sql` script. The data in the database will persist even after you shut the container down since it uses a docker-managed volume. If you need to clear out the database data, you can run `docker-compose down --volumes` in the `.devcontainer` directory.

This also changes the default dev port of the collaboration server to `3999`, since `3000` is the default for JBrowse Web.