### PR TITLE
Don't register schema multiple times

### DIFF
--- a/packages/apollo-collaboration-server/src/assemblies/assemblies.module.ts
+++ b/packages/apollo-collaboration-server/src/assemblies/assemblies.module.ts
@@ -13,5 +13,6 @@ import { AssembliesService } from './assemblies.service'
       { name: Assembly.name, schema: AssemblySchema },
     ]),
   ],
+  exports: [MongooseModule],
 })
 export class AssembliesModule {}

--- a/packages/apollo-collaboration-server/src/features/features.module.ts
+++ b/packages/apollo-collaboration-server/src/features/features.module.ts
@@ -1,9 +1,9 @@
 import { Module } from '@nestjs/common'
 import { MongooseModule, getConnectionToken } from '@nestjs/mongoose'
-import { Assembly, AssemblySchema } from 'apollo-schemas'
-import { RefSeq, RefSeqSchema } from 'apollo-schemas'
 import { Feature, FeatureSchema } from 'apollo-schemas'
 import idValidator from 'mongoose-id-validator'
+import { AssembliesModule } from 'src/assemblies/assemblies.module'
+import { RefSeqsModule } from 'src/refSeqs/refSeqs.module'
 
 import { FeaturesController } from './features.controller'
 import { FeaturesService } from './features.service'
@@ -12,10 +12,8 @@ import { FeaturesService } from './features.service'
   controllers: [FeaturesController],
   providers: [FeaturesService],
   imports: [
-    MongooseModule.forFeature([
-      { name: Assembly.name, schema: AssemblySchema },
-    ]),
-    MongooseModule.forFeature([{ name: RefSeq.name, schema: RefSeqSchema }]),
+    AssembliesModule,
+    RefSeqsModule,
     MongooseModule.forFeatureAsync([
       {
         name: Feature.name,

--- a/packages/apollo-collaboration-server/src/refSeqs/refSeqs.module.ts
+++ b/packages/apollo-collaboration-server/src/refSeqs/refSeqs.module.ts
@@ -19,6 +19,7 @@ import { RefSeqsService } from './refSeqs.service'
       },
     ]),
   ],
+  exports: [MongooseModule],
   controllers: [RefSeqsController],
   providers: [RefSeqsService],
 })


### PR DESCRIPTION
According to the [NestJS docs](https://docs.nestjs.com/techniques/mongodb#model-injection):

> If you also want to use the models in another module, add MongooseModule to the exports section of CatsModule and import CatsModule in the other module.

This applies that pattern, exporting `MongooseModule` from `AssembliesModule` and `RefSeqsModule` and importing those modules into `FeaturesModule`.