### PR TITLE
Add Feature schema indexes

### DIFF
--- a/packages/apollo-schemas/src/feature.schema.ts
+++ b/packages/apollo-schemas/src/feature.schema.ts
@@ -59,3 +59,6 @@ export class Feature implements GFF3FeatureLineWithRefs {
   derived_features: GFF3Feature[]
 }
 export const FeatureSchema = SchemaFactory.createForClass(Feature)
+
+FeatureSchema.index({ refSeq: 1, start: 1 })
+FeatureSchema.index({ refSeq: 1, end: 1 })


### PR DESCRIPTION
This adds compound indexes on refSeq+start and refSeq+end to the feature collection. This makes it so that this query that we do will use the index and work faster:

https://github.com/GMOD/jbrowse-plugin-apollo/blob/ccfb44117b04438269b245b85c752cfff8570200/packages/apollo-collaboration-server/src/features/features.service.ts#L228-L234