### PR TITLE
Add and run core validation

### DIFF
--- a/packages/apollo-collaboration-server/src/change/change.service.ts
+++ b/packages/apollo-collaboration-server/src/change/change.service.ts
@@ -1,13 +1,20 @@
 import { open } from 'fs/promises'
 import { join } from 'path'
 
-import { CACHE_MANAGER, Inject, Logger } from '@nestjs/common'
+import {
+  CACHE_MANAGER,
+  Inject,
+  Logger,
+  UnprocessableEntityException,
+} from '@nestjs/common'
 import { InjectModel } from '@nestjs/mongoose'
 import { Feature, FeatureDocument } from 'apollo-schemas'
 import {
+  CoreValidation,
   LocationEndChange,
   LocationStartChange,
   SerializedChange,
+  ValidationSet,
   changeRegistry,
 } from 'apollo-shared'
 import { Cache } from 'cache-manager'
@@ -24,6 +31,7 @@ export class ChangeService {
   }
 
   private readonly logger = new Logger(ChangeService.name)
+  private readonly validations = new ValidationSet([new CoreValidation()])
 
   async submitChange(serializedChange: SerializedChange) {
     // Get environment variable values and pass those as parameter to apply -method
@@ -41,8 +49,16 @@ export class ChangeService {
     const ChangeType = changeRegistry.getChangeType(serializedChange.typeName)
     const change = new ChangeType(serializedChange)
     this.logger.debug(`Requested change=${JSON.stringify(change)}`)
-    // TODO: validate change
-    // const result = await this.validations.backendPreValidate(change)
+    const validationResult = await this.validations.backendPreValidate(change)
+    if (!validationResult.ok) {
+      const errorMessage = validationResult.results
+        .map((r) => r.error?.message)
+        .filter(Boolean)
+        .join(', ')
+      throw new UnprocessableEntityException(
+        `Error in backend pre-validation: ${errorMessage}`,
+      )
+    }
     const gff3Handle = await open(
       join(FILE_SEARCH_FOLDER, GFF3_DEFAULT_FILENAME_TO_SAVE),
       'r+',
@@ -66,7 +82,18 @@ export class ChangeService {
         featureModel: this.featureModel,
         session,
       })
-      // const results2 = await this.validations.backendPostValidate(change)
+      const validationResult2 = await this.validations.backendPostValidate(
+        change,
+      )
+      if (!validationResult2.ok) {
+        const errorMessage = validationResult2.results
+          .map((r) => r.error?.message)
+          .filter(Boolean)
+          .join(', ')
+        throw new UnprocessableEntityException(
+          `Error in backend post-validation: ${errorMessage}`,
+        )
+      }
     })
     return []
   }

--- a/packages/apollo-shared/src/ChangeManager/ChangeManager.ts
+++ b/packages/apollo-shared/src/ChangeManager/ChangeManager.ts
@@ -19,7 +19,7 @@ export class ChangeManager {
     const result = await this.validations.frontendPreValidate(change)
     if (!result.ok) {
       session.notify(
-        `Change is not valid: "${result.results
+        `Pre-validation failed: "${result.results
           .map((r) => r.error?.message)
           .filter(Boolean)
           .join(', ')}"`,
@@ -53,7 +53,7 @@ export class ChangeManager {
     }
     if (!backendResult.ok) {
       session.notify(
-        `Change is not valid: "${result.results
+        `Post-validation failed: "${result.results
           .map((r) => r.error?.message)
           .filter(Boolean)
           .join(', ')}"`,

--- a/packages/apollo-shared/src/Validations/CoreValidation.ts
+++ b/packages/apollo-shared/src/Validations/CoreValidation.ts
@@ -1,0 +1,7 @@
+import { Validation } from './Validation'
+
+export class CoreValidation extends Validation {
+  getName() {
+    return 'Core'
+  }
+}

--- a/packages/apollo-shared/src/Validations/index.ts
+++ b/packages/apollo-shared/src/Validations/index.ts
@@ -1,2 +1,3 @@
 export * from './Validation'
 export * from './ValidationSet'
+export * from './CoreValidation'

--- a/packages/jbrowse-plugin-apollo/src/ApolloView/stateModel.ts
+++ b/packages/jbrowse-plugin-apollo/src/ApolloView/stateModel.ts
@@ -6,6 +6,7 @@ import { LinearGenomeViewStateModel } from '@jbrowse/plugin-linear-genome-view'
 import {
   ChangeManager,
   CollaborationServerDriver,
+  CoreValidation,
   FeaturesForRefName,
   ValidationSet,
 } from 'apollo-shared'
@@ -37,7 +38,10 @@ export const ClientDataStore = types
     }
   })
   .volatile((self) => ({
-    changeManager: new ChangeManager(self, new ValidationSet([])),
+    changeManager: new ChangeManager(
+      self,
+      new ValidationSet([new CoreValidation()]),
+    ),
   }))
 
 export function stateModelFactory(pluginManager: PluginManager) {


### PR DESCRIPTION
This adds a core validation (that doesn't do anything yet) and adds evaluation of the validation to the server (validations were already evaluated on the client). Draft for now since it will be merged after #78, and will probably need to be updated after that is merged to move the validation to the service instead of the controller.