### PR TITLE
Add option to pass NestJS logger to change objects

### DIFF
--- a/packages/apollo-collaboration-server/src/changes/changes.service.ts
+++ b/packages/apollo-collaboration-server/src/changes/changes.service.ts
@@ -56,7 +56,7 @@ export class ChangesService {
     envMap.set('GFF3_DEFAULT_FILENAME_TO_SAVE', GFF3_DEFAULT_FILENAME_TO_SAVE)
 
     const ChangeType = changeRegistry.getChangeType(serializedChange.typeName)
-    const change = new ChangeType(serializedChange)
+    const change = new ChangeType(serializedChange, { logger: this.logger })
     this.logger.debug(`Requested change: ${JSON.stringify(change)}`)
 
     const validationResult = await this.validations.backendPreValidate(change)

--- a/packages/apollo-shared/package.json
+++ b/packages/apollo-shared/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@gmod/gff": "^1.2.0",
     "@jbrowse/core": "^1.7.4",
+    "@nestjs/common": "^8.4.4",
     "apollo-schemas": "workspace:^",
     "regenerator-runtime": "^0.13.9",
     "tslib": "^2.3.1"

--- a/packages/apollo-shared/src/ChangeManager/Change.ts
+++ b/packages/apollo-shared/src/ChangeManager/Change.ts
@@ -34,22 +34,28 @@ export interface SerializedChange {
 
 export type DataStore = ServerDataStore | LocalGFF3DataStore | ClientDataStore
 
+export interface ChangeOptions {
+  logger: import('@nestjs/common').LoggerService
+}
+
 export abstract class Change implements SerializedChange {
+  protected logger: import('@nestjs/common').LoggerService
   abstract typeName: string
   abstract changes: unknown[]
 
   assemblyId: string
   changedIds: string[]
 
-  constructor(json: SerializedChange) {
+  constructor(json: SerializedChange, options?: ChangeOptions) {
     const { assemblyId, changedIds } = json
     this.assemblyId = assemblyId
     this.changedIds = changedIds
+    this.logger = options?.logger || console
   }
 
-  static fromJSON(json: SerializedChange): Change {
+  static fromJSON(json: SerializedChange, options?: ChangeOptions): Change {
     const ChangeType = changeRegistry.getChangeType(json.typeName)
-    return new ChangeType(json)
+    return new ChangeType(json, options?.logger && { logger: options.logger })
   }
 
   abstract toJSON(): SerializedChange

--- a/packages/apollo-shared/src/ChangeManager/FeatureChange.ts
+++ b/packages/apollo-shared/src/ChangeManager/FeatureChange.ts
@@ -25,18 +25,18 @@ export abstract class FeatureChange extends Change {
     feature: GFF3FeatureLineWithFeatureIdAndOptionalRefs,
     featureId: string,
   ): GFF3FeatureLineWithFeatureIdAndOptionalRefs | null {
-    console.debug(`Entry=${JSON.stringify(feature)}`)
+    this.logger.debug?.(`Entry=${JSON.stringify(feature)}`)
 
-    console.debug(`Top level featureId=${feature.featureId}`)
+    this.logger.debug?.(`Top level featureId=${feature.featureId}`)
     if (feature.featureId === featureId) {
-      console.debug(
+      this.logger.debug?.(
         `Top level featureId matches in object ${JSON.stringify(feature)}`,
       )
       return feature
     }
     // Check if there is also childFeatures in parent feature and it's not empty
     // Let's get featureId from recursive method
-    console.debug(
+    this.logger.debug?.(
       `FeatureId was not found on top level so lets make recursive call...`,
     )
     for (const childFeature of feature.child_features || []) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3395,6 +3395,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@nestjs/common@npm:^8.4.4":
+  version: 8.4.4
+  resolution: "@nestjs/common@npm:8.4.4"
+  dependencies:
+    axios: 0.26.1
+    iterare: 1.2.1
+    tslib: 2.3.1
+    uuid: 8.3.2
+  peerDependencies:
+    cache-manager: "*"
+    class-transformer: "*"
+    class-validator: "*"
+    reflect-metadata: ^0.1.12
+    rxjs: ^7.1.0
+  peerDependenciesMeta:
+    cache-manager:
+      optional: true
+    class-transformer:
+      optional: true
+    class-validator:
+      optional: true
+  checksum: bd0326a7a52b4ca819ca8790cec1e649ba0067d2eee54a32aabe890729f5d7dd6ecbf834cf68aa6727974a693981a4a6c119574dd12560914041380010632174
+  languageName: node
+  linkType: hard
+
 "@nestjs/config@npm:^1.0.3":
   version: 1.1.0
   resolution: "@nestjs/config@npm:1.1.0"
@@ -5374,6 +5399,7 @@ __metadata:
   dependencies:
     "@gmod/gff": ^1.2.0
     "@jbrowse/core": ^1.7.4
+    "@nestjs/common": ^8.4.4
     "@types/cache-manager": ^3
     "@types/node": ^16.0.0
     apollo-schemas: "workspace:^"
@@ -5719,6 +5745,15 @@ __metadata:
   dependencies:
     follow-redirects: ^1.14.4
   checksum: 468cf496c08a6aadfb7e699bebdac02851e3043d4e7d282350804ea8900e30d368daa6e3cd4ab83b8ddb5a3b1e17a5a21ada13fc9cebd27b74828f47a4236316
+  languageName: node
+  linkType: hard
+
+"axios@npm:0.26.1":
+  version: 0.26.1
+  resolution: "axios@npm:0.26.1"
+  dependencies:
+    follow-redirects: ^1.14.8
+  checksum: d9eb58ff4bc0b36a04783fc9ff760e9245c829a5a1052ee7ca6013410d427036b1d10d04e7380c02f3508c5eaf3485b1ae67bd2adbfec3683704745c8d7a6e1a
   languageName: node
   linkType: hard
 
@@ -9426,6 +9461,16 @@ __metadata:
     debug:
       optional: true
   checksum: f004a76b2ee3a849772c2816e30928253bf47537b0f00184d89f4966413add96a228a4d96ca8c702bc045a683c52c2ba41545c915cc1a5e33bf8fd9d07b59aee
+  languageName: node
+  linkType: hard
+
+"follow-redirects@npm:^1.14.8":
+  version: 1.14.9
+  resolution: "follow-redirects@npm:1.14.9"
+  peerDependenciesMeta:
+    debug:
+      optional: true
+  checksum: f5982e0eb481818642492d3ca35a86989c98af1128b8e1a62911a3410621bc15d2b079e8170b35b19d3bdee770b73ed431a257ed86195af773771145baa57845
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This adds the ability to pass the NestJS logger into the change objects. That means in a change you can use `this.logger.verbose('message')` and it will use NestJS's logger, which can be set to various log levels. It will use e.g. `console.verbose` when running in the browser.